### PR TITLE
Fix congestor real_n_measurements bug

### DIFF
--- a/congestors.c
+++ b/congestors.c
@@ -151,7 +151,7 @@ int congestor(CommConfig_t *config, int n_measurements, int niters, MPI_Comm tes
      timeout_t1 = MPI_Wtime();
      timeout    = 0.;
      mpi_error(MPI_Iallreduce(MPI_IN_PLACE, &timeout, 1, MPI_DOUBLE, MPI_MAX, test_comm, &req));
-     *real_n_measurements = 0;
+     if (record_perf) *real_n_measurements = 0;
      bt = 0.;
      for (m = 0; m < n_measurements; m++) {
 
@@ -194,7 +194,7 @@ int congestor(CommConfig_t *config, int n_measurements, int niters, MPI_Comm tes
           }
           bt2 = MPI_Wtime();
           bt += bt2 - bt1;
-          (*real_n_measurements)++;
+          if (record_perf) (*real_n_measurements)++;
      }
      if (req != MPI_REQUEST_NULL) {
           mpi_error(MPI_Wait(&req, MPI_STATUS_IGNORE));


### PR DESCRIPTION
Bug: sometimes congestors report many zero values in their performance.

How it occurs:
1) run_congestor_tests loops through the Congestors multiple times until the Probes finish
2) on the first iteration, congestor is called with measure_perf=1 (record performance of congestors)
3) congestors record real_n_measurmenets*niters fine-grained timing results in an array
4) on subsequent iterations measure_perf=0, so no new timing results are recorded. However, real_n_measurements can be modified.
4.1) if real_n_measurmenets is less than the first time, some measurements will be left out in the final output
4.2) if real_n_measurements is greater than the first time, you will get whatever malloc put in the unwritten part of the array (in our case those were all 0s it seems)

Proposed fix:
check value of record_perf before editing real_n_measurements as well (2 places in congestor(...))