### PR TITLE
adding in a DL training congestor based off the Rice Data Science 201…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This benchmark suite consists of two applications:
 
-network_test: Full system network tests in random and natural ring, alltoall 
+network_test: Full system network tests in random and natural ring, alltoall
               and allreduce
 
 network_load_test: Select full system network tests run with four congestors to
@@ -45,7 +45,7 @@ or
 
 aprun -n 2304 -N 36 ./network_load_test
 
-Each application has no arguments.  
+Each application has no arguments.
 
 # Benchmarking Practices
 
@@ -53,7 +53,7 @@ GPCNeT applications should be run at full system scale, in particular
 network_load_test. network_test can be run at any scale above 2 nodes to
 measure the capability of a network for complex communication patterns.
 
-network_load_test should not be run at much less than full system scale 
+network_load_test should not be run at much less than full system scale
 (ie, run on at least 95% of system nodes).  The results
 will likely not be representative if the network has significant head room.  Additionally,
 the spirit of this benchmark is that it is run with default network and MPI configuration
@@ -62,8 +62,8 @@ network and MPI configuration is used, the baseline performance for communicatio
 inspected with network_test prior to measuring congestion impacts with network_load_test.
 
 The primary tuning parameter users can use is the number of processes per NIC (PPN).
-We refer to process per NIC (rather than process per node) because modern nodes span a wide range of capabilities.  
-Consider a dual socket node with 2 NICS and 6 GPUs vs a single socket single NIC node. 
+We refer to process per NIC (rather than process per node) because modern nodes span a wide range of capabilities.
+Consider a dual socket node with 2 NICS and 6 GPUs vs a single socket single NIC node.
 The number of NICs is a reasonable proxy for expected communication capability.
 The higher the PPN the more the benchmark will push the network.  For the network_test,
 higher PPN will push bandwidth per NIC (note the benchmark reports bandwidth per rank)
@@ -95,7 +95,7 @@ congestors can be lessened by reducing the number of processes per NIC or
 modifying the message sizes of congestors.
 
 Tuning of message sizes and loop counts is done with the defs at the beginning of
-network_test.c or network_load_test.c.  For example, to modify the message size of 
+network_test.c or network_load_test.c.  For example, to modify the message size of
 of the one-sided incast look for this line in network_load_test.c
 
 #define INCAST_MSG_COUNT 512
@@ -109,3 +109,9 @@ Please contact any of the following people if you have any questions.
 * Taylor Groves (tgroves@lbl.gov)
 * Sudheer Chunduri (sudheer@anl.gov)
 * Pete Mendygral (pjm@cray.com)
+
+# ChangeLog #
+
+4/3/2020: Adding in a new congestor type that mimics the allreduce operations for DL training.  It is based on
+          the paper presented on at 2019 Rice Data Science Conference
+          https://2019datascienceconference.sched.com/event/UYuZ/sharing-resources-in-the-age-of-deep-learning

--- a/network_test.c
+++ b/network_test.c
@@ -21,7 +21,7 @@
 #include <time.h>
 #include <network_test.h>
 
-#define VERSION 1.1
+#define VERSION 1.2
 
 #define NUM_NETWORK_TESTS 8
 
@@ -44,7 +44,7 @@
 
 CommTest_t network_tests_list[NUM_NETWORK_TESTS];
 
-int network_test_setup(CommTest_t req_test, int *ntests, int *nrands, int *niters, 
+int network_test_setup(CommTest_t req_test, int *ntests, int *nrands, int *niters,
                        char *tname, char *tunits)
 {
      int nl=64;
@@ -124,8 +124,8 @@ int main(int argc, char* argv[])
      int itest, niters, ntests, nrands, i;
      int *allnodes;
 
-     init_mpi(&test_config, &nodes, &argc, &argv, BW_MSG_COUNT, BW_MSG_COUNT, A2A_MSG_COUNT, 
-              1, 1, BW_OUTSTANDING);
+     init_mpi(&test_config, &nodes, &argc, &argv, BW_MSG_COUNT, BW_MSG_COUNT, A2A_MSG_COUNT,
+              1, 1, 1, BW_OUTSTANDING);
 
      if (nodes.nnodes < 2) {
           if (test_config.myrank == 0) {
@@ -160,26 +160,26 @@ int main(int argc, char* argv[])
           printf("  Test with %i MPI ranks (%i nodes)\n\n", test_config.nranks, nodes.nnodes);
           printf("  Legend\n   RR = random ring communication pattern\n   Nat = natural ring communication pattern\n   Lat = latency\n   BW = bandwidth\n   BW+Sync = bandwidth with barrier");
      }
-    
+
      /* gather the baseline performance */
      results.distribution = NULL;
      print_header(&test_config, 0, 0);
      for (itest = 0; itest < NUM_NETWORK_TESTS; itest++) {
 
           network_test_setup(network_tests_list[itest], &ntests, &nrands, &niters, tname, tunits);
-          if (network_tests_list[itest] != A2A_BANDWIDTH && network_tests_list[itest] 
+          if (network_tests_list[itest] != A2A_BANDWIDTH && network_tests_list[itest]
               != P2P_BANDWIDTH_NAT && network_tests_list[itest] != ALLREDUCE_LATENCY) {
-               random_ring(&test_config, 0, ntests, nrands, niters, network_tests_list[itest], 
+               random_ring(&test_config, 0, ntests, nrands, niters, network_tests_list[itest],
                            TEST_NULL, test_comm, MPI_COMM_WORLD, &results);
           } else if (network_tests_list[itest] == P2P_BANDWIDTH_NAT) {
-               random_ring(&test_config, 1, ntests, nrands, niters, P2P_BANDWIDTH, TEST_NULL, 
+               random_ring(&test_config, 1, ntests, nrands, niters, P2P_BANDWIDTH, TEST_NULL,
                            test_comm, MPI_COMM_WORLD, &results);
           } else if (network_tests_list[itest] == A2A_BANDWIDTH) {
                a2a_test(&test_config, ntests, niters, test_comm, MPI_COMM_WORLD, &results);
           } else if (network_tests_list[itest] == ALLREDUCE_LATENCY) {
                allreduce_test(&test_config, ntests, niters, test_comm, MPI_COMM_WORLD, &results);
           }
-    
+
           int from_min = 0;
           if (network_tests_list[itest] == P2P_LATENCY || network_tests_list[itest] == RMA_LATENCY ||
               network_tests_list[itest] == ALLREDUCE_LATENCY) from_min = 1;

--- a/network_test.h
+++ b/network_test.h
@@ -66,12 +66,15 @@ typedef struct CommConfig_st {
      double *p2p_buffer;
      double *a2a_sbuffer;
      double *a2a_rbuffer;
+     double *ar_sbuffer;
+     double *ar_rbuffer;
      MPI_Win rma_window;
      MPI_Win rma_a2a_window;
      int bw_outstanding;
      int p2pbw_cnt;
      int rmabw_cnt;
      int a2a_cnt;
+     int ar_cnt;
      int incast_cnt;
      int bcast_cnt;
      int myrank;
@@ -94,6 +97,7 @@ typedef enum CommTest_st
      P2P_BCAST_CONGESTOR,
      RMA_INCAST_CONGESTOR,
      RMA_BCAST_CONGESTOR,
+     ALLREDUCE_CONGESTOR,
      TEST_CONGESTORS,
      TEST_NULL
 } CommTest_t;
@@ -114,45 +118,61 @@ typedef struct CommResults_st {
 } CommResults_t;
 
 /* random_ring.c */
-int random_ring(CommConfig_t *config, int norand, int n_measurements, int nrands, int niters, CommTest_t req_test, CommTest_t other_test,
+int random_ring(CommConfig_t *config, int norand, int n_measurements, int nrands, int niters,
+                CommTest_t req_test, CommTest_t other_test,
                 MPI_Comm comm, MPI_Comm global_comm, CommResults_t *results);
 int finalize_mpi(CommConfig_t *config, CommNodes_t *nodes);
-int p2p_latency(CommConfig_t *config, int lneighbor, int rneighbor, int niters, MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
-int p2p_bandwidth(CommConfig_t *config, int lneighbor, int rneighbor, int niters, MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
-int rma_latency(CommConfig_t *config, int lneighbor, int rneighbor, int niters, MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
-int rma_bandwidth(CommConfig_t *config, int lneighbor, int rneighbor, int niters, MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
-int p2p_neighbors(CommConfig_t *config, int lneighbor, int rneighbor, int niters, MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
+int p2p_latency(CommConfig_t *config, int lneighbor, int rneighbor, int niters,
+                MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
+int p2p_bandwidth(CommConfig_t *config, int lneighbor, int rneighbor, int niters,
+                  MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
+int rma_latency(CommConfig_t *config, int lneighbor, int rneighbor, int niters,
+                MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
+int rma_bandwidth(CommConfig_t *config, int lneighbor, int rneighbor, int niters,
+                  MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
+int p2p_neighbors(CommConfig_t *config, int lneighbor, int rneighbor, int niters,
+                  MPI_Comm global_comm, MPI_Comm comm, double *perfvals, double *perfval);
 
 /* collectives.c */
-int a2a_test(CommConfig_t *config, int ntests, int base_niters, MPI_Comm a2acomm, MPI_Comm global_comm, CommResults_t * results);
-int allreduce_test(CommConfig_t *config, int ntests, int niters, MPI_Comm comm, MPI_Comm global_comm, CommResults_t * results);
+int a2a_test(CommConfig_t *config, int ntests, int base_niters, MPI_Comm a2acomm,
+             MPI_Comm global_comm, CommResults_t * results);
+int allreduce_test(CommConfig_t *config, int ntests, int niters, MPI_Comm comm,
+                   MPI_Comm global_comm, CommResults_t * results);
 
 /* subcomms.c */
-int split_subcomms(int nsubcomms, MPI_Comm local_comm, MPI_Comm base_comm, int *color, MPI_Comm *test_comm, MPI_Comm *subcomm);
-int node_slice_subcomms(CommConfig_t *config, CommNodes_t *nodes, int *node_list, int list_size, MPI_Comm *subcomm);
-int congestion_subcomms(CommConfig_t *config, CommNodes_t *nodes, int *congestor_node_list, int list_size, int *am_congestor, MPI_Comm *subcomm);
+int split_subcomms(int nsubcomms, MPI_Comm local_comm, MPI_Comm base_comm, int *color,
+                   MPI_Comm *test_comm, MPI_Comm *subcomm);
+int node_slice_subcomms(CommConfig_t *config, CommNodes_t *nodes, int *node_list,
+                        int list_size, MPI_Comm *subcomm);
+int congestion_subcomms(CommConfig_t *config, CommNodes_t *nodes, int *congestor_node_list,
+                        int list_size, int *am_congestor, MPI_Comm *subcomm);
 
 /* utils.c */
 void die(char *errmsg);
 void mpi_error(int ierr);
-int init_mpi(CommConfig_t *config, CommNodes_t *nodes, int *argc, char ***argv, int rmacnt, int p2pcnt, int a2acnt, int incastcnt, 
-             int bcastcnt, int bw_outstanding);
+int init_mpi(CommConfig_t *config, CommNodes_t *nodes, int *argc, char ***argv, int rmacnt,
+             int p2pcnt, int a2acnt, int incastcnt, int bcastcnt, int allreducecnt, int bw_outstanding);
 int init_rma(CommConfig_t *config, MPI_Comm comm);
 int init_rma_a2a(CommConfig_t *config, MPI_Comm comm);
 int a2a_buffers(CommConfig_t *config, MPI_Comm subcomm);
+int allreduce_buffers(CommConfig_t *config, MPI_Comm comm);
 void shuffle(int *list, int size, int seed, int call);
-int print_results(CommConfig_t *config, int localrank, int havedata, int from_min, char *name, char *units, CommResults_t * results);
+int print_results(CommConfig_t *config, int localrank, int havedata, int from_min,
+                  char *name, char *units, CommResults_t * results);
 int print_comparison_results(CommConfig_t *config, int localrank, int havedata, int from_min,
                              char *name, CommResults_t * base_results, CommResults_t * results);
 int print_header(CommConfig_t *config, int type, CommTest_t ctype);
-int summarize_performance(CommConfig_t *config, double *myperf_vals_hires, double *myperf_vals, int total_vals_hires, int total_vals, 
+int summarize_performance(CommConfig_t *config, double *myperf_vals_hires,
+                          double *myperf_vals, int total_vals_hires, int total_vals,
                           int from_min, MPI_Comm comm, CommResults_t *results);
-int write_distribution(CommTest_t req_test, CommTest_t other_test, int isbaseline, CommResults_t * results, char * tname, char * tunits);
-int summarize_pairs_performance(CommConfig_t *config, MPI_Comm comm, char *lnode, char *rnode, double *myperf_vals, int nsamps, int m, int r, 
+int write_distribution(CommTest_t req_test, CommTest_t other_test, int isbaseline,
+                       CommResults_t * results, char * tname, char * tunits);
+int summarize_pairs_performance(CommConfig_t *config, MPI_Comm comm, char *lnode,
+                                char *rnode, double *myperf_vals, int nsamps, int m, int r,
                                 CommTest_t req_test, CommTest_t other_test);
 
 /* congestors.c */
-int congestor(CommConfig_t *config, int n_measurements, int niters, MPI_Comm test_comm, CommTest_t req_test, 
+int congestor(CommConfig_t *config, int n_measurements, int niters, MPI_Comm test_comm, CommTest_t req_test,
               int record_perf, double * perfvals, double * perfval, int *real_n_measurements);
 int p2p_incast_congestor(CommConfig_t *config, MPI_Comm comm, int myrank, int comm_ranks);
 int a2a_congestor(CommConfig_t *config, MPI_Comm comm, int myrank, int comm_ranks);


### PR DESCRIPTION
The paper presented on at the 2019 Data Science Conference discussed how DL training can caused congestion and congestion on a network.  This PR includes the code needed to reproduce the results discussed in that paper.  Users can enable a congestor of this kind with the type ALLREDUCE_CONGESTOR.  It is designed to approximate ResNet50 when run at 16 processes per node (cumulative 100 MB message).

The paper can be seen here:
https://2019datascienceconference.sched.com/event/UYuZ/sharing-resources-in-the-age-of-deep-learning