### PR TITLE
Updating Makefile to accommodate MPI compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 CFLAGS = -I .
 LIBS = -lm
-CC = cc
 FLAGS = 
+
+ifdef $(CC)
+	ifeq ($(CC), mpicc)
+		LIBS = -lm -lmpi
+	endif
+else
+	CC = cc
+endif
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS) $(FLAGS)


### PR DESCRIPTION
This is an update to allow easily building with an MPI compiler by simply specifying `CC=mpicc` on the make command line